### PR TITLE
Spell delay fix #2 - Spell delay config

### DIFF
--- a/Framework/Configuration/Settings.cs
+++ b/Framework/Configuration/Settings.cs
@@ -25,5 +25,8 @@ namespace Framework
         public static readonly bool DebugOutput = Conf.GetBoolean("DebugOutput", false);
         public static readonly bool PacketsLog = Conf.GetBoolean("PacketsLog", true);
         public static readonly bool RememberLastCharacter = Conf.GetBoolean("RememberLastCharacter", true);
+        public static readonly bool EnableSpellDelay = Conf.GetBoolean("EnableSpellDelay", false);
+        public static readonly int ServerDelay = Conf.GetInt("ServerDelay", 0);
+        public static readonly int ClientDelay = Conf.GetInt("ClientDelay", 0);
     }
 }

--- a/HermesProxy/HermesProxy.config
+++ b/HermesProxy/HermesProxy.config
@@ -95,5 +95,24 @@
             Default:     "true"
     -->
     <add key="RememberLastCharacter" value="true" />
+    <!--
+            Option:      EnableSpellDelay
+            Description: Enables artificital lag for spell packets.
+                         To prevent spells bugging out if they are being spammed.
+            Default:     "false"
+    -->
+    <add key="EnableSpellDelay" value="false" />
+    <!--
+            Option:      ServerDelay
+            Description: The amount of spell delay for Server in milliseconds.
+            Default:     "0"
+    -->
+    <add key="ServerDelay" value="0" />
+    <!--
+            Option:      ClientDelay
+            Description: The amount of spell delay for Client in milliseconds.
+            Default:     "0"
+    -->
+    <add key="ClientDelay" value="0" />
   </appSettings>
 </configuration>

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -128,7 +128,10 @@ namespace HermesProxy.World.Client
         {
             // Artificial lag is needed for spell packets,
             // or spells will bug out and glow if spammed.
-            System.Threading.Thread.Sleep(70);
+            if (Settings.EnableSpellDelay)
+            {
+                System.Threading.Thread.Sleep(Settings.ClientDelay);
+            }
 
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
                 packet.ReadUInt8(); // cast count
@@ -196,7 +199,10 @@ namespace HermesProxy.World.Client
         {
             // Artificial lag is needed for spell packets,
             // or spells will bug out and glow if spammed.
-            System.Threading.Thread.Sleep(70);
+            if (Settings.EnableSpellDelay)
+            {
+                System.Threading.Thread.Sleep(Settings.ClientDelay);
+            }
 
             uint spellId = packet.ReadUInt32();
             var status = packet.ReadUInt8();
@@ -232,7 +238,10 @@ namespace HermesProxy.World.Client
         {
             // Artificial lag is needed for spell packets,
             // or spells will bug out and glow if spammed.
-            System.Threading.Thread.Sleep(70);
+            if (Settings.EnableSpellDelay)
+            {
+                System.Threading.Thread.Sleep(Settings.ClientDelay);
+            }
 
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
                 packet.ReadUInt8(); // cast count
@@ -282,7 +291,10 @@ namespace HermesProxy.World.Client
             {
                 // Artificial lag is needed for spell packets,
                 // or spells will bug out and glow if spammed.
-                System.Threading.Thread.Sleep(70);
+                if (Settings.EnableSpellDelay)
+                {
+                    System.Threading.Thread.Sleep(Settings.ClientDelay);
+                }
             }
 
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
@@ -442,7 +454,10 @@ namespace HermesProxy.World.Client
             {
                 // Artificial lag is needed for spell packets,
                 // or spells will bug out and glow if spammed.
-                System.Threading.Thread.Sleep(70);
+                if (Settings.EnableSpellDelay)
+                {
+                    System.Threading.Thread.Sleep(Settings.ClientDelay);
+                }
             }
 
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
@@ -621,7 +636,10 @@ namespace HermesProxy.World.Client
         {
             // Artificial lag is needed for spell packets,
             // or spells will bug out and glow if spammed.
-            System.Threading.Thread.Sleep(70);
+            if (Settings.EnableSpellDelay)
+            {
+                System.Threading.Thread.Sleep(Settings.ClientDelay);
+            }
 
             if (GetSession().GameState.CurrentClientSpecialCast != null &&
                 GameData.AutoRepeatSpells.Contains(GetSession().GameState.CurrentClientSpecialCast.SpellId))

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -1,4 +1,5 @@
-﻿using Framework.Constants;
+﻿using Framework;
+using Framework.Constants;
 using HermesProxy.Enums;
 using HermesProxy.World;
 using HermesProxy.World.Enums;
@@ -106,7 +107,10 @@ namespace HermesProxy.World.Server
         {
             // Artificial lag is needed for spell packets,
             // or spells will bug out and glow if spammed.
-            System.Threading.Thread.Sleep(50);
+            if (Settings.EnableSpellDelay)
+            {
+                System.Threading.Thread.Sleep(Settings.ServerDelay);
+            }
 
             if (GameData.NextMeleeSpells.Contains(cast.Cast.SpellID) ||
                 GameData.AutoRepeatSpells.Contains(cast.Cast.SpellID))
@@ -196,7 +200,10 @@ namespace HermesProxy.World.Server
         {
             // Artificial lag is needed for spell packets,
             // or spells will bug out and glow if spammed.
-            System.Threading.Thread.Sleep(50);
+            if (Settings.EnableSpellDelay)
+            {
+                System.Threading.Thread.Sleep(Settings.ServerDelay);
+            }
 
             ClientCastRequest castRequest = new ClientCastRequest();
             castRequest.Timestamp = Environment.TickCount;
@@ -247,7 +254,10 @@ namespace HermesProxy.World.Server
         {
             // Artificial lag is needed for spell packets,
             // or spells will bug out and glow if spammed.
-            System.Threading.Thread.Sleep(50);
+            if (Settings.EnableSpellDelay)
+            {
+                System.Threading.Thread.Sleep(Settings.ServerDelay);
+            }
 
             ClientCastRequest castRequest = new ClientCastRequest();
             castRequest.Timestamp = Environment.TickCount;
@@ -302,7 +312,10 @@ namespace HermesProxy.World.Server
         {
             // Artificial lag is needed for spell packets,
             // or spells will bug out and glow if spammed.
-            System.Threading.Thread.Sleep(50);
+            if (Settings.EnableSpellDelay)
+            {
+                System.Threading.Thread.Sleep(Settings.ServerDelay);
+            }
 
             WorldPacket packet = new WorldPacket(Opcode.CMSG_CANCEL_CAST);
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
@@ -315,7 +328,10 @@ namespace HermesProxy.World.Server
         {
             // Artificial lag is needed for spell packets,
             // or spells will bug out and glow if spammed.
-            System.Threading.Thread.Sleep(50);
+            if (Settings.EnableSpellDelay)
+            {
+                System.Threading.Thread.Sleep(Settings.ServerDelay);
+            }
 
             WorldPacket packet = new WorldPacket(Opcode.CMSG_CANCEL_CHANNELLING);
             packet.WriteInt32(cast.SpellID);
@@ -363,7 +379,10 @@ namespace HermesProxy.World.Server
         {
             // Artificial lag is needed for spell packets,
             // or spells will bug out and glow if spammed.
-            System.Threading.Thread.Sleep(50);
+            if (Settings.EnableSpellDelay)
+            {
+                System.Threading.Thread.Sleep(Settings.ServerDelay);
+            }
 
             WorldPacket packet = new WorldPacket(Opcode.CMSG_CANCEL_AUTO_REPEAT_SPELL);
             SendPacketToServer(packet);


### PR DESCRIPTION
Added enabling/disabling and adjusting the amount of spell delay for both client and server in the config file.